### PR TITLE
Hotfix/kamailio segfaults fake reply and malloc

### DIFF
--- a/src/modules/ims_auth/cxdx_mar.c
+++ b/src/modules/ims_auth/cxdx_mar.c
@@ -541,7 +541,7 @@ int cxdx_send_mar(struct sip_msg *msg, str public_identity, str private_identity
     }
     if (!cxdx_add_server_name(mar, server_name)) goto error1;
 
-    if (msg && msg->callid) {
+    if ((NULL != msg) && (FAKED_REPLY != msg) && (NULL != msg->callid)) {
         correlationID = get_callid(msg);
     } else {
         correlationID = NULL;

--- a/src/modules/ims_charging/ims_ro.c
+++ b/src/modules/ims_charging/ims_ro.c
@@ -1230,7 +1230,7 @@ int Ro_Send_CCR(struct sip_msg *msg, struct dlg_cell *dlg, int dir, int reservat
 //    new_session->ccr_sent = 1;      //assume we will send successfully
     cdpb.AAASessionsUnlock(cc_acc_session->hash);
 
-    if (msg && msg->callid) {
+    if ((NULL != msg) && (FAKED_REPLY != msg) && (NULL != msg->callid)) {
         correlationID = &msg->callid->body;
     } else {
         correlationID = NULL;

--- a/src/modules/ims_diameter_server/ims_diameter_server.c
+++ b/src/modules/ims_diameter_server/ims_diameter_server.c
@@ -307,7 +307,7 @@ int diameter_request(struct sip_msg * msg, char* peer, char* appid, char* comman
 		return -1;
 	}
 
-    if (msg && msg->callid) {
+    if ((NULL != msg) && (FAKED_REPLY != msg) && (NULL != msg->callid)) {
         correlationID = &msg->callid->body;
     } else {
         correlationID = NULL;

--- a/src/modules/ims_icscf/cxdx_lir.c
+++ b/src/modules/ims_icscf/cxdx_lir.c
@@ -254,7 +254,7 @@ int cxdx_send_lir(struct sip_msg *msg, str public_identity, saved_lir_transactio
     if (!cxdx_add_auth_session_state(lir, 1)) goto error1;
     if (!cxdx_add_public_identity(lir, public_identity)) goto error1;
 
-    if (msg && msg->callid) {
+    if ((NULL != msg) && (FAKED_REPLY != msg) && (NULL != msg->callid)) {
         correlationID = &msg->callid->body;
     } else {
         correlationID = NULL;

--- a/src/modules/ims_icscf/cxdx_uar.c
+++ b/src/modules/ims_icscf/cxdx_uar.c
@@ -294,7 +294,7 @@ int cxdx_send_uar(struct sip_msg *msg, str private_identity, str public_identity
     if (authorization_type != AVP_IMS_UAR_REGISTRATION)
         if (!cxdx_add_authorization_type(uar, authorization_type)) goto error1;
 
-    if (msg && msg->callid) {
+    if ((NULL != msg) && (FAKED_REPLY != msg) && (NULL != msg->callid)) {
         correlationID = &msg->callid->body;
     } else {
         correlationID = NULL;

--- a/src/modules/ims_ipsec_pcscf/cmd.c
+++ b/src/modules/ims_ipsec_pcscf/cmd.c
@@ -208,6 +208,12 @@ static int fill_contact(struct pcontact_info* ci, struct sip_msg* m)
         memset(&req_msg, 0, sizeof(struct sip_msg));
         req_msg.buf =
             (char*) pkg_malloc((t->uas.request->len + 1) * sizeof(char));
+
+        if (NULL == req_msg.buf) {
+            LM_ERR("req_msg.buf malloc failed\n");
+            return -1;
+        }
+
         memcpy(req_msg.buf, t->uas.request->buf, t->uas.request->len);
         req_msg.buf[t->uas.request->len] = '\0';
         req_msg.len = t->uas.request->len;

--- a/src/modules/ims_qos/ims_qos_mod.c
+++ b/src/modules/ims_qos/ims_qos_mod.c
@@ -437,8 +437,8 @@ void callback_dialog(struct dlg_cell* dlg, int type, struct dlg_cb_params * para
 				return;
 		}
 
-		if ((NULL != msg) &&
-		    (NULL != msg->callid)) {
+		if ((NULL != msg) && (FAKED_REPLY != msg) && (NULL != msg->callid))
+		{
 			callid = &msg->callid->body;
 		}
 

--- a/src/modules/ims_qos/rx_aar.c
+++ b/src/modules/ims_qos/rx_aar.c
@@ -914,7 +914,7 @@ int rx_send_aar(struct sip_msg *req, struct sip_msg *res,
     if (auth)
         cdpb.AAASessionsUnlock(auth->hash);
 
-    if (req && req->callid) {
+    if ((NULL != req) && (FAKED_REPLY != req) && (NULL != req->callid)) {
         correlationID = &req->callid->body;
     } else {
         correlationID = NULL;
@@ -1060,7 +1060,7 @@ int rx_send_aar_register(struct sip_msg *msg, AAASession* auth, saved_transactio
     if (auth)
         cdpb.AAASessionsUnlock(auth->hash);
 
-    if (msg && msg->callid) {
+    if ((NULL != msg) && (FAKED_REPLY != msg) && (NULL != msg->callid)) {
         correlationID = &msg->callid->body;
     } else {
         correlationID = NULL;

--- a/src/modules/ims_registrar_scscf/cxdx_sar.c
+++ b/src/modules/ims_registrar_scscf/cxdx_sar.c
@@ -363,7 +363,7 @@ int cxdx_send_sar(struct sip_msg *msg, str public_identity, str private_identity
     }
 
     /* TODO: use cscf_get_call_id instead? */
-    if (msg && msg->callid) {
+    if ((NULL != msg) && (FAKED_REPLY != msg) && (NULL != msg->callid)) {
         correlationID = &msg->callid->body;
     } else {
         correlationID = NULL;


### PR DESCRIPTION
When looking at the recent segfaults I found 2 core dumps and I've addresses the segfault issue in both.
1) An issue relating to kamailio using a FAKE_REPLY sip messages which is kinda a 'valid but invalid' pointer (-1/0xFFF... instead of NULL or a valid pointer address) so it was getting past out NULL checks and being used as if it was a valid message.
2) There was a malloc fail which wasn't being checked and a NULL pointer was being referenced. Something to do with sip replys and filling out contact info.

I have a feeling that the runaway resource usage issue we've been seeing may have something to do with this? If so I expect to see a bunch of `req_msg.buf malloc failed` error messages